### PR TITLE
replaced the named argument for nilnil in the call to OJ with a hash …

### DIFF
--- a/lib/jsonlint/linter.rb
+++ b/lib/jsonlint/linter.rb
@@ -74,7 +74,7 @@ module JsonLint
     end
 
     def check_syntax_valid?(json_data, errors_array)
-      Oj.load(json_data, nilnil: false)
+      Oj.load(json_data, {"nilnil" => false})
       true
     rescue Oj::ParseError => e
       errors_array << e.message


### PR DESCRIPTION
…in order to extend compatibility back to Ruby 1.8.7

I looked through the rest of the code after making this change, and this appears to be the only line that breaks compatibility. I know it's kind of a weird thing to do, but unfortunately the environment I'm working in doesn't allow me to upgrade Ruby beyond 1.8.7 at the moment.

Since the main dependency for this is OJ, and OJ itself is backwards compatible to 1.8.7 I thought it would be nice if this gem could also be.