### PR TITLE
fix markdown table syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ spec/data/overlapping_keys.json
 Add these options similarly to the path option seen above.
 
 | Option | Description | Default |
-| ------------- | ------------- | ------------- | ------------- |
+| ------------- | ------------- | ------------- |
 | `exclude_paths` | List of files or paths to exclude from linting | `nil` |
 | `fail_on_error` | Continue on to the next rake task when false and don't fail even if JsonLint finds errors | `true` |
 | `log_level` | Logger level (DEBUG, INFO, WARN, ERROR, FATAL, or UNKNOWN) | `INFO` |


### PR DESCRIPTION
remove extra header column to make the table render  correctly.