### PR TITLE
Disable unsafe loading

### DIFF
--- a/lib/jsonlint/linter.rb
+++ b/lib/jsonlint/linter.rb
@@ -79,7 +79,7 @@ module JsonLint
     end
 
     def check_syntax_valid?(json_data, errors_array)
-      Oj.load(json_data, nilnil: false)
+      Oj.load(json_data, nilnil: false, mode: :strict)
       true
     rescue Oj::ParseError => e
       errors_array << e.message

--- a/spec/data/serialised.json
+++ b/spec/data/serialised.json
@@ -1,0 +1,1 @@
+{"^o":"SerialisationTestWhichDefinitelyDoesNotExist"}

--- a/spec/linter_spec.rb
+++ b/spec/linter_spec.rb
@@ -40,4 +40,8 @@ describe 'JsonLint::Linter' do
   it 'should be unhapy with a JSON file full of spaces' do
     expect(linter.check(spec_data('lots_of_spaces.json'))).to be(false)
   end
+
+  it 'should not deserialise objects' do
+    expect(linter.check(spec_data('serialised.json'))).to be(true)
+  end
 end


### PR DESCRIPTION
Ensure serialised objects are not deserialised during linting.
This makes sure third-party JSON files cannot be turned into exploits.